### PR TITLE
Unfreezed Pony.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 async-lru==1.0.2
-
+pony
 pyaes==1.6.1
 Pyrogram==1.2.9
 PySocks==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 async-lru==1.0.2
-pony
+
 pyaes==1.6.1
 Pyrogram==1.2.9
 PySocks==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 async-lru==1.0.2
-pony==0.7.14
+pony
 pyaes==1.6.1
 Pyrogram==1.2.9
 PySocks==1.7.1


### PR DESCRIPTION
If pony version was freezed then heroku deploy was not possible as that version was only supported in python 3.3-3.9.
After unfreezeing it , the repository is deployable to heroku without any conflict with latest python version.